### PR TITLE
various misc patches for better library accessibility and reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ let request_headers_precedence = vec![
 ```
 
 You can customize the order by providing your own list using IpWareConfig.
-```rust no_run
+```rust
 use ipware::IpWareConfig;
 use http::HeaderName;
 // specific header name
@@ -111,12 +111,12 @@ IpWareConfig::new(vec![HeaderName::from_static("http_x_forwarded_for")],true);
 
 // multiple header names
 IpWareConfig::new(
-               vec![
-                   HeaderName::from_static("http_x_forwarded_for"),
-                   HeaderName::from_static("x_forwarded_for"),
-               ],
-               true,
-           );
+    vec![
+        HeaderName::from_static("http_x_forwarded_for"),
+        HeaderName::from_static("x_forwarded_for"),
+    ],
+    true,
+);
 ```
 
 #### 🤝 Trusted Proxies
@@ -127,20 +127,18 @@ by providing a `trusted proxy list`, or a known proxy `count`.
 You can customize the proxy IP prefixes by providing your own list by using IpWareProxy.
 You can pass your custom list on every call, when calling the proxy-aware api to fetch the ip.
 
-```rust no_run
+```rust
 // In the above scenario, use your load balancer IP address as a way to filter out unwanted requests.
 use std::net::IpAddr;
-use ipware::IpWare;
-use ipware::IpWareConfig;
-use ipware::IpWareProxy;
-use http::HeaderMap;
+
+use ipware::{HeaderMap, IpWare, IpWareConfig, IpWareProxy};
 
 let headers = HeaderMap::new(); // replace this with your own headers
 let proxies = vec![
-            "198.84.193.157".parse::<IpAddr>().unwrap(),
-            "198.84.193.158".parse::<IpAddr>().unwrap(),
-        ];
-let ipware = IpWare::new(IpWareConfig::default(), IpWareProxy::new(0, &proxies));
+    "198.84.193.157".parse::<IpAddr>().unwrap(),
+    "198.84.193.158".parse::<IpAddr>().unwrap(),
+];
+let ipware = IpWare::new(IpWareConfig::default(), IpWareProxy::new(0, proxies));
 
 // usage: non-strict mode (X-Forwarded-For: <fake>, <client>, <proxy1>, <proxy2>)
 // The request went through our <proxy1> and <proxy2>, then our server
@@ -159,7 +157,7 @@ let (ip, trusted_route) = ipware.get_client_ip(&headers, true);
 If your http server is behind a `known` number of proxies, but you deploy on multiple providers and don't want to track proxy IPs, you still can filter out unwanted requests by providing proxy `count`.
 
 You can customize the proxy count by providing your `proxy_count` using IpWareProxy.
-```rust no_run
+```rust
 use ipware::*;
 use std::net::IpAddr;
 
@@ -168,11 +166,11 @@ use std::net::IpAddr;
 
 let headers = HeaderMap::new(); // replace this with your own headers
 let proxies = vec![];
-let ipware = IpWare::new(IpWareConfig::default(), IpWareProxy::new(1, &proxies));
+let ipware = IpWare::new(IpWareConfig::default(), IpWareProxy::new(1, proxies));
 
 // enforce proxy count and trusted proxies
 let proxies = vec!["198.84.193.157".parse::<IpAddr>().unwrap()];
-let ipware = IpWare::new(IpWareConfig::default(), IpWareProxy::new(1, &proxies));
+let ipware = IpWare::new(IpWareConfig::default(), IpWareProxy::new(1, proxies));
 
 // usage: non-strict mode (X-Forwarded-For: <fake>, <client>, <proxy1>, <proxy2>)
 // total number of ip addresses are greater than the total count
@@ -197,7 +195,7 @@ for the originating client IP address is the `leftmost`as per`client, proxy1, pr
 trusted proxy.
 However, in rare cases your network has a `custom` configuration where the `rightmost` IP address is that of the originating client. If that is the case, then indicate it when creating:
 ```
-```rust no_run
+```rust
 use ipware::*;
 let ipware = IpWare::new(
     IpWareConfig::default().leftmost(false),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -347,23 +347,19 @@ impl<'a> IpWare<'a> {
         let mut loopback_list = vec![];
         let mut private_list = vec![];
         let meta_values = self.get_meta_values(headers);
-        dbg!(&self.proxy.proxy_list.len());
         for &meta_value in meta_values.iter() {
             let meta_ips = self.get_ips_from_string(meta_value.to_str().unwrap().to_owned());
             if meta_ips.is_empty() {
                 continue;
             }
             let proxy_count_validated = self.proxy.is_proxy_count_valid(&meta_ips, strict);
-            dbg!(&proxy_count_validated);
             if !proxy_count_validated {
                 continue;
             }
             let proxy_list_validated = self.proxy.is_proxy_trusted_list_valid(&meta_ips, strict);
-            dbg!(&proxy_list_validated);
             if !proxy_list_validated {
                 continue;
             }
-            dbg!(meta_ips.clone());
             let (client_ip, trusted_route) =
                 self.get_best_ip(&meta_ips, proxy_count_validated, proxy_list_validated);
             if let Some(client_ip) = client_ip {
@@ -429,7 +425,6 @@ impl<'a> IpWare<'a> {
         if ip_list.is_empty() {
             return (None, false);
         }
-        dbg!(&self.proxy.proxy_list);
         if !self.proxy.proxy_list.is_empty() && proxy_list_validated {
             return (ip_list.iter().rev().nth(self.proxy.proxy_list.len()), true);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -335,11 +335,12 @@ impl<'a> IpWare<'a> {
         }
     }
 
-    fn get_meta_values<'b>(&self, headers: &'b HeaderMap) -> Vec<&'b HeaderValue> {
+    fn get_meta_values(&self, headers: &'a HeaderMap) -> Vec<&'a str> {
         self.config
             .precedence
             .iter()
             .filter_map(|header_name| self.get_meta_value(headers, header_name))
+            .filter_map(|header_value| header_value.to_str().ok())
             .collect::<Vec<_>>()
     }
 
@@ -348,7 +349,7 @@ impl<'a> IpWare<'a> {
         let mut private_list = vec![];
         let meta_values = self.get_meta_values(headers);
         for &meta_value in meta_values.iter() {
-            let meta_ips = self.get_ips_from_string(meta_value.to_str().unwrap().to_owned());
+            let meta_ips = self.get_ips_from_string(meta_value);
             if meta_ips.is_empty() {
                 continue;
             }
@@ -390,7 +391,7 @@ impl<'a> IpWare<'a> {
     ///
     /// # Arguments
     /// * `ip_str` - String contains , seperated ip addresses
-    fn get_ips_from_string(&self, ip_str: String) -> Vec<IpAddr> {
+    fn get_ips_from_string(&self, ip_str: &str) -> Vec<IpAddr> {
         let mut result = ip_str
             .split(',')
             .map(|single_ip| {


### PR DESCRIPTION
Fixes https://github.com/orhanbalci/ipware/issues/3.

Covers removing `dbg!` statements, removes `unwrap` from standard operations preventing panics on non-utf8 strings, and removes lifetime from `IpWareProxy` and `IpWare` making them more portable and easy to use for various implementations.

Additionally, it adds missing `Clone/Debug/Default` implementations for each of the primary components and makes minor tweaks to the logic to make things more idiomatic and readable.